### PR TITLE
Fixed 'Provider "gps" unknown'

### DIFF
--- a/android/app/src/main/java/com/twolinessoftware/android/PlaybackService.kt
+++ b/android/app/src/main/java/com/twolinessoftware/android/PlaybackService.kt
@@ -54,7 +54,6 @@ class PlaybackService : Service(), GpxSaxParserListener {
 
         @Throws(RemoteException::class)
         override fun stopService() {
-            mLocationManager?.removeTestProvider(PROVIDER_NAME)
             queue?.reset()
             broadcastStateChange(STOPPED)
             cancelExistingTaskIfNecessary()
@@ -94,12 +93,12 @@ class PlaybackService : Service(), GpxSaxParserListener {
                     .setContentText("").build()
             startForeground(1, notification)
         }
-        setupTestProvider()
-        processing = false
     }
 
     override fun onStartCommand(intent: Intent, flags: Int, startId: Int): Int {
         Log.d(LOG, "Starting Playback Service")
+        setupTestProvider()
+        processing = false
 
         val staticLocation = intent.getStringExtra(INTENT_STATIC_LOCATION)
         if (staticLocation != null) {


### PR DESCRIPTION
Stopping the playback causes error:
`    java.lang.IllegalArgumentException: Provider "gps" unknown
        at android.os.Parcel.createException(Parcel.java:2075)
        at android.os.Parcel.readException(Parcel.java:2039)
        at android.os.Parcel.readException(Parcel.java:1987)
        at android.location.ILocationManager$Stub$Proxy.setTestProviderLocation(ILocationManager.java:2069)
        at android.location.LocationManager.setTestProviderLocation(LocationManager.java:1516)
        at com.twolinessoftware.android.SendLocationWorker.sendLocation(SendLocationWorker.kt:57)
        at com.twolinessoftware.android.SendLocationWorker.run(SendLocationWorker.kt:28)
        at com.twolinessoftware.android.SendLocationWorkerQueue$WorkerThread.run(SendLocationWorkerQueue.java:108)
     Caused by: android.os.RemoteException: Remote stack trace:
        at com.android.server.LocationManagerService.setTestProviderLocation(LocationManagerService.java:3597)
        at android.location.ILocationManager$Stub.onTransact(ILocationManager.java:987)
        at android.os.Binder.execTransactInternal(Binder.java:1021)
        at android.os.Binder.execTransact(Binder.java:994)`
        
The solution:
- removing `mLocationManager?.removeTestProvider(PROVIDER_NAME)` from `stopService` function (it has been called too quickly)
- moving `        setupTestProvider()
        processing = false` from `onCreate` to `onStartCommand` function (When restarting the route error `Provider "gps" unknown` appeared again) - need to recreate provider